### PR TITLE
Support for multiple fill format token

### DIFF
--- a/src/passthrough/__init__.py
+++ b/src/passthrough/__init__.py
@@ -15,6 +15,7 @@ del _dist_meta
 
 PT_NS = {"prefix": "pt", "uri": __url__}
 PT_EXT_URI_BASE = f"{__url__}/extensions"
+FILL_TOKEN = "{}"
 
 from . import exc, extensions, label_tools
 from .template import Template


### PR DESCRIPTION
Treat members of node sets as format token substitutions for fill
expressions declared outside of multi branch contexts (where they
would otherwise be greedily mapped to branches instead).

Fill expressions within multi branches are currently unable to declare
more than one substitution (see #10).