### PR TITLE
feat: allow fetched children to follow src order

### DIFF
--- a/src/passthrough/state.py
+++ b/src/passthrough/state.py
@@ -41,6 +41,7 @@ class PTState(UserDict):
             ("fill", Property(default=None, inherit=False, types=(str,))),
             ("defer", Property(default=False, inherit=False, types=(bool,))),
             ("multi_branch", Property(default=None, inherit=True, types=(int,))),
+            ("reorder", Property(default=False, inherit=False, types=(bool,))),
         ]
     )
 
@@ -218,6 +219,11 @@ class PTState(UserDict):
         if self.exp["fill"] and len(self.t_elem):
             raise PTStateError("pt:fill defined on a PDS4 class", self.t_elem)
         if not self["fetch"]:
+            # TODO: evaluate if there are any use cases that argue against this
+            if self["reorder"] is True:
+                raise PTStateError(
+                    f'pt:reorder="true()" outside a pt:fetch context is not allowed'
+                )
             if self["multi"] is True:
                 raise PTStateError(
                     f'pt:multi="true()" outside a pt:fetch context is nonsensical',


### PR DESCRIPTION
Introduce `pt:reorder`, which if present on a fetched class will ensure
that the document order of its children corresponds as closely as
possible with that of the active source element. Children unique to
the template element will cling on to their originally proceeding
sibling, avoiding most PDS4 order related pitfalls.

Note that the only reason for introducing this property is to put out
the burning dumpster fire that is the interleaving of
{,Group_}Field_Binary children of dynamic cardinality in Table_Binary
classes, where document order unfortunately matters a lot.

This property should be revised at a later point when the dust settles,
as is not well aligned with the core PT mantra of WYSIWYG.